### PR TITLE
Fix duplication of module table.

### DIFF
--- a/lua/academic.lua
+++ b/lua/academic.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 ---@class AcademicOptions
 M.opts = {


### PR DESCRIPTION
I was seeing a duplicated instance of M. The second instance didn't have M initialized properly. 

I'm clueless when it comes to lua and nvim plugin development, but looking at other plugins, they all used `local`. Trying that fixed the errors for me. I hope this change makes sense.