### PR TITLE
Neovim 0.12 support

### DIFF
--- a/lua/academic.lua
+++ b/lua/academic.lua
@@ -17,7 +17,7 @@ local function get_dictionary()
 end
 
 local function get_spell(dir)
-	local spell_dir = vim.fn["spellfile#WritableSpellDir"]() .. "/"
+	local spell_dir = vim.fn.stdpath("data") .. "/site/spell/"
 	if dir then
 		return spell_dir
 	else


### PR DESCRIPTION
There is no `spellfile#WritableSpellDir`, the dir is in `stdpath("data") .. "/site/spell/"`, according to https://neovim.io/doc/user/options/#'spellfile'.